### PR TITLE
Allow optionally setting MemoryMax in systemd for ipfs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,11 @@ ipfs_routing: dht
 ipfs_disable_bandthwidth_metrics: false
 ipfs_reprovider_strategy: all
 
+# If you find IPFS uses too much RAM, you can
+# limit the max amount in the systemd service
+# file by setting this to something suitable:
+# ipfs_memory_max: "1.5G"
+
 # IPFS Cluster
 
 # override to disable ipfs cluster setup

--- a/templates/ipfs/etc/systemd/system/ipfs.service
+++ b/templates/ipfs/etc/systemd/system/ipfs.service
@@ -9,6 +9,9 @@ Group=ipfs
 StateDirectory=ipfs
 TimeoutStartSec=10800
 LimitNOFILE={{ ipfs_fd_max }}
+{% if ipfs_memory_max is defined %}
+MemoryMax={{ ipfs_memory_max }}
+{% endif %}
 MemorySwapMax=0
 Environment="IPFS_FD_MAX={{ ipfs_fd_max}}"
 ExecStart=/usr/local/bin/ipfs daemon --migrate {%- if ipfs_enable_gc | default(False) %} --enable-gc{% endif %}


### PR DESCRIPTION
Hi @madoke !

Thanks for your improvements to the upstream ansible-ipfs-cluster role. I have been using yours for some months without much issue.

The one issue I have had, is that I've noticed ipfs gradually uses more and more RAM. Probably a memory leak, or maybe just a 'cache' filling up. Depending on the size of the machine running the service, this can pose a problem.

To help control it, I've set MemoryMax in the systemd unit file. Thought I'd offer a PR for it as an *optional* parameter. Thanks!