### PR TITLE
Switch to use kubo instead of go-ipfs as of v0.36.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Ansible role for `go-ipfs` and `ipfs-cluster`
+# Ansible role for `kubo` and `ipfs-cluster`
 
 This repository contains an Ansible role to install and run
-[`go-ipfs`](https://github.com/ipfs/go-ipfs) and
+[`kubo`](ihttps://github.com/ipfs/kubo) and
 [`IPFS Cluster`](https://github.com/ipfs/ipfs-cluster).
 
 They include a Systemd service file both.
@@ -25,7 +25,7 @@ that fits you best. Otherwise follow these steps:
 - Create `group_vars/ipfs.yml` and `group_vars/ipfs_cluster.yml` files setting the right configuration values including generating an [IPFS Cluster secret](https://cluster.ipfs.io/documentation/guides/security/#the-cluster-secret) with `od -vN 32 -An -tx1 /dev/urandom | tr -d ' \n' ; echo`. More details in the [Group Vars](#group-vars) section.
 - Add a file for each hostname (filename is the hostname), to the `host_vars` folder as outlined in [Host Vars](#host-vars), containing the necessary host-specific variables (example in the `molecule/default/molecule.yml` file).
 
-Upon successful execution, both `go-ipfs` and `ipfs-cluster` should be running in the nodes (they are installed under `/usr/local/bin` and run by a created `ipfs` system user).
+Upon successful execution, both `kubo` and `ipfs-cluster` should be running in the nodes (they are installed under `/usr/local/bin` and run by a created `ipfs` system user).
 
 You can use `systemctl status ipfs` and `systemctl status ipfs-cluster` to check the status of the new services.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 # IPFS
 
-# override to disable go-ipfs setup
+# override to disable kubo setup
 ipfs_enable: true
 
 ipfs_version: v0.9.0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: Hector Sanjuan
-  description: Ansible role to install and run go-ipfs and IPFS Cluster
+  description: Ansible role to install and run kubo and IPFS Cluster
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value

--- a/tasks/ipfs/main.yml
+++ b/tasks/ipfs/main.yml
@@ -1,10 +1,10 @@
-- name: create download folder for go-ipfs
+- name: create download folder for kubo
   become: yes
   file:
     state: directory
     owner: root
     group: root
-    dest: /opt/go-ipfs/{{ipfs_version}}
+    dest: /opt/kubo/{{ipfs_version}}
 
 - name: download and unpack IPFS
   when: not ansible_check_mode
@@ -12,27 +12,27 @@
     - name: download IPFS
       become: yes
       get_url:
-        url: "{{ dist_url }}/go-ipfs/{{ipfs_version}}/go-ipfs_{{ipfs_version}}_linux-{{ipfs_arch}}.tar.gz"
-        dest: /opt/go-ipfs/{{ipfs_version}}/go-ipfs.tar.gz
+        url: "{{ dist_url }}/kubo/{{ipfs_version}}/kubo_{{ipfs_version}}_linux-{{ipfs_arch}}.tar.gz"
+        dest: /opt/kubo/{{ipfs_version}}/kubo.tar.gz
         timeout: 30
 
-    - name: unpack go-ipfs
+    - name: unpack kubo
       become: yes
       unarchive:
         remote_src: yes
-        src: /opt/go-ipfs/{{ipfs_version}}/go-ipfs.tar.gz
-        dest: /opt/go-ipfs/{{ipfs_version}}
-        creates: /opt/go-ipfs/{{ipfs_version}}/go-ipfs
+        src: /opt/kubo/{{ipfs_version}}/kubo.tar.gz
+        dest: /opt/kubo/{{ipfs_version}}
+        creates: /opt/kubo/{{ipfs_version}}/kubo
       notify: restart IPFS
 
-    - name: link go-ipfs executable
+    - name: link kubo executable
       become: yes
       file:
         state: link
         owner: root
         group: root
         dest: /usr/local/bin/ipfs
-        src: /opt/go-ipfs/{{ipfs_version}}/go-ipfs/ipfs
+        src: /opt/kubo/{{ipfs_version}}/kubo/ipfs
 
 - name: install ipfs systemd init service
   become: yes
@@ -88,34 +88,6 @@
     creates: "{{ ipfs_home }}/.ipfs/config"
   notify: restart IPFS
 
-- name: download and unpack NOpfs
-  when: not ansible_check_mode
-  block:
-    - name: create plugins folder
-      become: yes
-      file:
-        state: directory
-        owner: ipfs
-        group: ipfs
-        dest: "{{ ipfs_home }}/.ipfs/plugins"
-
-    - name: download and unpack nopfs
-      when: not ansible_check_mode
-      become: yes
-      unarchive:
-        remote_src: yes
-        src: "https://github.com/ipfs-shipyard/nopfs/releases/download/nopfs-kubo-plugin/{{nopfs_version}}/nopfs-kubo-plugin_{{nopfs_version}}_linux_{{ipfs_arch}}.tar.gz"
-        dest: "{{ ipfs_home }}/.ipfs/plugins/"
-        include:
-          - nopfs-kubo-plugin/nopfs-kubo-plugin
-        extra_opts:
-          - "--strip-components=1"
-        owner: ipfs
-        group: ipfs
-      notify: restart IPFS
-  tags:
-    - nopfs
-
 - name: set version file (to notify restart on upgrades)
   become: yes
   copy:
@@ -125,7 +97,7 @@
     owner: ipfs
     group: ipfs
   notify: restart IPFS
-
+  
 - name: reload systemd
   become: yes
   systemd:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,1 +1,1 @@
-dist_url: https://dist.ipfs.io
+dist_url: https://dist.ipfs.tech


### PR DESCRIPTION
Hi @madoke ,

As of Kubo v0.36.0, using this ansible role to fetch that version throws an error trying to restart IPFS. The error is:

> the name 'go-ipfs' is no longer used. please update your package manager scripts to 'kubo' and download from https://dist.ipfs.tech/kubo/ instead.

I've found that simply replacing go-ipfs with kubo seems to be enough. I've not tested the 'cluster' service, just the standalone.

I've also had problems with the 'NOpfs' stuff for some time and have no need for it personally, so I just removed that altogether, but you might wish to put that back in if it's working for you.