### PR TITLE
Add default values for ipfs_connmgr_low_water / ipfs_connmgr_high_water variables. Change GracePeriod to an optional variable too

### DIFF
--- a/templates/ipfs/home/ipfs/ipfs_default_config
+++ b/templates/ipfs/home/ipfs/ipfs_default_config
@@ -187,9 +187,9 @@
     },
     "ConnMgr": {
       "Type": "basic",
-      "LowWater": {{ ipfs_connmgr_low_water }},
-      "HighWater": {{ ipfs_connmgr_high_water }},
-      "GracePeriod": "30s"
+      "LowWater": {{ ipfs_connmgr_low_water | default(32) }},
+      "HighWater": {{ ipfs_connmgr_high_water | default(96) }},
+      "GracePeriod": "{{ ipfs_connmgr_grace_period | default('30s') }}"
     },
     "ResourceMgr": {
       "MaxMemory": "{{ ipfs_resourcemgr_max_memory | default(0) }}"


### PR DESCRIPTION
I got an error on ipfs_default_config because of two variables that I had not defined.

All other variables look to have defaults, so I added defaults for these too - taking from https://github.com/ipfs/kubo/blob/master/config/init.go#L83-L89

While I was at it, I converted GracePeriod into a variable too, but keeping the existing default.