### PR TITLE
Fix permissions on kubo subfolders.

### DIFF
--- a/tasks/ipfs-cluster/main.yml
+++ b/tasks/ipfs-cluster/main.yml
@@ -4,6 +4,7 @@
     state: directory
     owner: root
     group: root
+    mode: 0755
     dest: /opt/ipfs-cluster/{{ipfs_cluster_version}}
 
 - name: download and unpack IPFS Cluster
@@ -26,6 +27,18 @@
         src: /opt/ipfs-cluster/{{ipfs_cluster_version}}/{{ item }}.tar.gz
         dest: /opt/ipfs-cluster/{{ipfs_cluster_version}}/
         creates: /opt/ipfs-cluster/{{ipfs_cluster_version}}/{{ item }}
+      with_items:
+        - ipfs-cluster-service
+        - ipfs-cluster-ctl
+
+    - name: Ensure permissions are 0755 for the subfolders
+      become: yes
+      file:
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+        dest: /opt/ipfs-cluster/{{ipfs_cluster_version}}/{{ item }}
       with_items:
         - ipfs-cluster-service
         - ipfs-cluster-ctl
@@ -65,7 +78,7 @@
     dest: /etc/init.d/ipfs-cluster
     owner: root
     group: root
-    mode: 0744
+    mode: 0755
   notify:
     - restart IPFS Cluster
   when:

--- a/tasks/ipfs/main.yml
+++ b/tasks/ipfs/main.yml
@@ -4,6 +4,7 @@
     state: directory
     owner: root
     group: root
+    mode: 0755
     dest: /opt/kubo/{{ipfs_version}}
 
 - name: download and unpack IPFS
@@ -24,6 +25,15 @@
         dest: /opt/kubo/{{ipfs_version}}
         creates: /opt/kubo/{{ipfs_version}}/kubo
       notify: restart IPFS
+
+    - name: Ensure version-specific kubo subfolder is readable by ipfs user
+      become: yes
+      file:
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+        dest: /opt/kubo/{{ipfs_version}}/kubo
 
     - name: link kubo executable
       become: yes
@@ -59,7 +69,7 @@
     dest: /etc/init.d/ipfs
     owner: root
     group: root
-    mode: 0744
+    mode: 0755
   notify:
     - restart IPFS
   when:


### PR DESCRIPTION
On a system with umask 027, the version-specific kubo folder and its subfolder are not accessible to the 'ipfs' user, and ipfs won't start. Enforce 0755 on these folders.

Whilst I was there, I thought 744 looked weird on an init script (though technically ok), so changed it to 755 out of convention.